### PR TITLE
The Google Cloud SDK needs a new package, so that kubectl can

### DIFF
--- a/src/sv/container_image/gcloud.clj
+++ b/src/sv/container_image/gcloud.clj
@@ -10,6 +10,6 @@
    ["bash" "-c" "echo \"deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main\" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list"]
    ["bash" "-c" "curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -"]
    (apt/update params)
-   (apt/install {:apt/packages ["google-cloud-sdk"]})
+   (apt/install {:apt/packages ["google-cloud-sdk" "google-cloud-sdk-gke-gcloud-auth-plugin"]})
    ]
   )


### PR DESCRIPTION
authenticate with GKE.

https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke